### PR TITLE
Use CSB BOM and update to latest 3.20.1

### DIFF
--- a/templates/amq/csb-jms-amqp-app/pom.xml
+++ b/templates/amq/csb-jms-amqp-app/pom.xml
@@ -14,10 +14,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.boot-version>2.7.6</spring.boot-version>
+    <spring.boot-version>2.7.12</spring.boot-version>
     <surefire.plugin.version>3.0.0-M4</surefire.plugin.version>
     <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-11:1.14</jkube.generator.from>
-    <camel.version>3.18.3.redhat-00025</camel.version>
+    <camel.version>3.20.1.redhat-00064</camel.version>
     <camel.rest.version>3.18.3</camel.rest.version>
     <spring.cloud-version>2022.0.1</spring.cloud-version>
     <spring.cloud.kubernetes-config-version>1.0.1.RELEASE</spring.cloud.kubernetes-config-version>
@@ -28,17 +28,8 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Spring Boot BOM -->
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot-version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <!-- Camel BOM -->
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
+        <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>camel-spring-boot-bom</artifactId>
         <version>${camel.version}</version>
         <type>pom</type>
@@ -52,7 +43,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/templates/amq/csb-jms-bean-app/pom.xml
+++ b/templates/amq/csb-jms-bean-app/pom.xml
@@ -14,10 +14,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.boot-version>2.7.6</spring.boot-version>
+    <spring.boot-version>2.7.12</spring.boot-version>
     <surefire.plugin.version>3.0.0-M4</surefire.plugin.version>
     <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-11:1.14</jkube.generator.from>
-    <camel.version>3.18.3.redhat-00025</camel.version>
+    <camel.version>3.20.1.redhat-00064</camel.version>
     <camel.rest.version>3.18.3</camel.rest.version>
     <spring.cloud-version>2022.0.1</spring.cloud-version>
     <spring.cloud.kubernetes-config-version>1.0.1.RELEASE</spring.cloud.kubernetes-config-version>
@@ -28,23 +28,14 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Spring Boot BOM -->
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot-version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <!-- Camel BOM -->
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
+        <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>camel-spring-boot-bom</artifactId>
         <version>${camel.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
+      
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-dependencies</artifactId>
@@ -52,7 +43,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
 
@@ -88,7 +78,6 @@
     <dependency>
       <groupId>org.apache.activemq</groupId>
       <artifactId>artemis-jms-client</artifactId>
-      <version>${redhat.amq7.client.version}</version>
     </dependency>  
  
     <!--        

--- a/templates/jetty/csb-http-app/pom.xml
+++ b/templates/jetty/csb-http-app/pom.xml
@@ -14,11 +14,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.boot-version>2.7.6</spring.boot-version>
+    <spring.boot-version>2.7.12</spring.boot-version>
     <surefire.plugin.version>3.0.0-M4</surefire.plugin.version>
     <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-11:1.14</jkube.generator.from>
-    <camel.version>3.18.3.redhat-00025</camel.version>
-    <camel.rest.version>3.18.3</camel.rest.version>
+    <camel.version>3.20.1.redhat-00064</camel.version>
     <spring.cloud-version>2022.0.1</spring.cloud-version>
     <spring.cloud.kubernetes-config-version>1.0.1.RELEASE</spring.cloud.kubernetes-config-version>
     <cxf.version>3.5.3.redhat-00033</cxf.version>
@@ -26,17 +25,8 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Spring Boot BOM -->
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot-version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <!-- Camel BOM -->
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
+        <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>camel-spring-boot-bom</artifactId>
         <version>${camel.version}</version>
         <type>pom</type>
@@ -50,7 +40,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
 

--- a/templates/rest/csb-xml-rest-app/pom.xml
+++ b/templates/rest/csb-xml-rest-app/pom.xml
@@ -16,11 +16,11 @@
     <maven.compiler.release>11</maven.compiler.release> 	  
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.boot-version>2.7.6</spring.boot-version>
+    <spring.boot-version>2.7.12</spring.boot-version>
     <surefire.plugin.version>3.0.0-M4</surefire.plugin.version>
     <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-17:1.16-1.1687182768</jkube.generator.from>
-    <camel.version>3.18.3.redhat-00025</camel.version>
-    <camel.rest.version>3.18.3</camel.rest.version>
+    <camel.version>3.20.1.redhat-00064</camel.version>
+    <camel.rest.version>3.20.1</camel.rest.version>
     <spring.cloud-version>2022.0.1</spring.cloud-version>
     <spring.cloud.kubernetes-config-version>1.0.1.RELEASE</spring.cloud.kubernetes-config-version>
     <openshift-maven-plugin-version>1.9.1.redhat-00004</openshift-maven-plugin-version>
@@ -29,17 +29,8 @@
 
   <dependencyManagement>
     <dependencies>
-      <!-- Spring Boot BOM -->
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot-version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <!-- Camel BOM -->
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
+        <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>camel-spring-boot-bom</artifactId>
         <version>${camel.version}</version>
         <type>pom</type>
@@ -53,7 +44,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
 
@@ -146,8 +136,8 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-compiler-plugin</artifactId>
-	<version>${compiler-plugin.version}</version>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${compiler-plugin.version}</version>
         <configuration>
           <compilerArgs>
             <arg>-parameters</arg>

--- a/templates/soap/csb-xml-soap-client/pom.xml
+++ b/templates/soap/csb-xml-soap-client/pom.xml
@@ -14,29 +14,19 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.boot-version>2.7.6</spring.boot-version>
+    <spring.boot-version>2.7.12</spring.boot-version>
     <surefire.plugin.version>3.0.0-M4</surefire.plugin.version>
     <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-11:1.14</jkube.generator.from>
-    <camel.version>3.18.3.redhat-00025</camel.version>
-    <camel.rest.version>3.18.3</camel.rest.version>
+    <camel.version>3.20.1.redhat-00064</camel.version>
     <spring.cloud-version>2022.0.1</spring.cloud-version>
     <spring.cloud.kubernetes-config-version>1.0.1.RELEASE</spring.cloud.kubernetes-config-version>
-    <cxf.version>3.5.3.redhat-00033</cxf.version>
+    <cxf.version>3.5.5.redhat-00041</cxf.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
-      <!-- Spring Boot BOM -->
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot-version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <!-- Camel BOM -->
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
+        <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>camel-spring-boot-bom</artifactId>
         <version>${camel.version}</version>
         <type>pom</type>
@@ -50,7 +40,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
 
@@ -108,7 +97,6 @@
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-spring-boot-starter-jaxws</artifactId>
-      <version>${cxf.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.springframework.boot</groupId>
@@ -124,7 +112,6 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-ws-security</artifactId>
-      <version>3.5.3.redhat-00033</version>
     </dependency>    
 
     <dependency>

--- a/templates/soap/csb-xml-soap-server/pom.xml
+++ b/templates/soap/csb-xml-soap-server/pom.xml
@@ -14,29 +14,19 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <spring.boot-version>2.7.6</spring.boot-version>
+    <spring.boot-version>2.7.12</spring.boot-version>
     <surefire.plugin.version>3.0.0-M4</surefire.plugin.version>
     <jkube.generator.from>registry.access.redhat.com/ubi8/openjdk-11:1.14</jkube.generator.from>
-    <camel.version>3.18.3.redhat-00025</camel.version>
-    <camel.rest.version>3.18.3</camel.rest.version>
+    <camel.version>3.20.1.redhat-00064</camel.version>
     <spring.cloud-version>2022.0.1</spring.cloud-version>
     <spring.cloud.kubernetes-config-version>1.0.1.RELEASE</spring.cloud.kubernetes-config-version>
-    <cxf.version>3.5.3.redhat-00033</cxf.version>
+    <cxf.version>3.5.5.redhat-00041</cxf.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
-      <!-- Spring Boot BOM -->
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot-version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <!-- Camel BOM -->
-      <dependency>
-        <groupId>org.apache.camel.springboot</groupId>
+        <groupId>com.redhat.camel.springboot.platform</groupId>
         <artifactId>camel-spring-boot-bom</artifactId>
         <version>${camel.version}</version>
         <type>pom</type>
@@ -50,7 +40,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-
     </dependencies>
   </dependencyManagement>
 
@@ -108,7 +97,6 @@
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-spring-boot-starter-jaxws</artifactId>
-      <version>${cxf.version}</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.springframework.boot</groupId>
@@ -124,7 +112,6 @@
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-ws-security</artifactId>
-      <version>3.5.3.redhat-00033</version>
     </dependency>    
 
     <dependency>


### PR DESCRIPTION
Hello @mthirion , Thanks to Sergio and Bruno I found out this repository, I think that the csb template can be improved using the `platform` BOM we are shipping as part of CSB, both 3.14 (latest), 3.18 (latest) and 3.20 ship this BOM that handle dependencies (CVE fixes, fixed client version like artemis..)